### PR TITLE
fix: update config directory path in config_loader

### DIFF
--- a/shared/utils/config_loader.py
+++ b/shared/utils/config_loader.py
@@ -15,7 +15,7 @@ def load_config(config_name: str) -> Dict[str, Any]:
     Returns:
         Dict containing the configuration data
     """
-    config_dir = Path(__file__).parent.parent / 'config'
+    config_dir = Path(__file__).parent.parent.parent / 'config'
     config_path = config_dir / f"{config_name}.yaml"
     
     with open(config_path, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
- Changed the config directory path from shared/config to config in the project root
- This fixes the FileNotFoundError when loading configuration files
- The config files are now correctly loaded from the project root's config directory